### PR TITLE
最初のパラグラフの変更の提案

### DIFF
--- a/0176-enforce-exclusive-access-to-memory.md
+++ b/0176-enforce-exclusive-access-to-memory.md
@@ -42,13 +42,10 @@ Swift3では、
 変数がプログラムの他の箇所から使われているか変更されている最中に、
 それを変更することが可能である。
 これは予想外だったり混乱する結果をもたらしうる。
-これは、
-たとえ稀な状況においてもプログラムの基本的な安全性
+それはさらに、コンパイラと標準ライブラリの実装に対して、
+多大な保守を強いる。それらは稀な状況下でもプログラムの基本的な健全性
 (クラッシュや未定義の動作が起こらない事)
-を
-一般に保証せねばならない
-コンパイラと標準ライブラリの実装に対して、
-大量の保守性を強制させもする。
+を一般に保証せねばならないからである。
 
 We propose that Swift should instead enforce a general rule that potential
 modifications of variables must be exclusive with any other access to that


### PR DESCRIPTION
後半の文の並びをより英文に近い感じに、いくつかの細かい訳語の変更の提案をする。